### PR TITLE
Proxy sparkui links

### DIFF
--- a/jupyter-spark/spark.py
+++ b/jupyter-spark/spark.py
@@ -5,7 +5,7 @@ import tornado
 import os
 import logging
 import json
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 
 EXTENSION_URL = "/spark"
 
@@ -36,21 +36,17 @@ class SparkHandler(IPythonHandler):
 
             if "text" in content_type:
                 # Replace all the relative links with our proxy links
-                soup = BeautifulSoup(spark_response.text)
+                soup = BeautifulSoup(spark_response.text, "html.parser")
 
                 for has_href in ['a', 'link']:
-                    for a in soup.findAll(has_href):
-                        try:
+                    for a in soup.find_all(has_href):
+                        if "href" in a.attrs:
                             a['href'] = url_path_join(self.web_app, a['href'])
-                        except KeyError:
-                            print "boo", a
 
                 for has_src in ['img', 'script']:
-                    for a in soup.findAll(has_src):
-                        try:
+                    for a in soup.find_all(has_src):
+                        if "src" in a.attrs:
                             a['src'] = url_path_join(self.web_app, a['src'])
-                        except KeyError:
-                            print "boo", a
 
                 client_response = str(soup)
             else:

--- a/jupyter-spark/spark.py
+++ b/jupyter-spark/spark.py
@@ -5,6 +5,7 @@ import tornado
 import os
 import logging
 import json
+from BeautifulSoup import BeautifulSoup
 
 EXTENSION_URL = "/spark"
 
@@ -18,17 +19,45 @@ def raise_error(msg):
 
 class SparkHandler(IPythonHandler):
     spark_host = None
+    web_app = None
 
     def get(self):
         #tornado_logger.info("Received URI from client: " + self.request.uri)
         if not self.request.uri.startswith(EXTENSION_URL):
             raise_error("URI did not start with " + EXTENSION_URL)
-        spark_request = spark_host + self.request.uri[len(EXTENSION_URL):]
+        spark_request = self.spark_host + self.request.uri[len(EXTENSION_URL):]
         #tornado_logger.info("Sending request to Spark UI: " + spark_request)
 
         try:
             spark_response = requests.get(spark_request)
-            client_response = spark_response.text
+
+            content_type = spark_response.headers['content-type']
+            self.set_header("Content-Type", content_type)
+
+            if "text" in content_type:
+                # Replace all the relative links with our proxy crap
+                soup = BeautifulSoup(spark_response.text)
+
+                for has_href in ['a', 'link']:
+                    for a in soup.findAll(has_href):
+                        try:
+                            a['href'] = url_path_join(self.web_app, a['href'])
+                        except KeyError:
+                            print "boo", a
+
+                for has_src in ['img', 'script']:
+                    for a in soup.findAll(has_src):
+                        try:
+                            a['src'] = url_path_join(self.web_app, a['src'])
+                        except KeyError:
+                            print "boo", a
+
+                client_response = str(soup)
+            else:
+                # Probably binary response, send it directly.
+                client_response = spark_response.content
+
+
             #tornado_logger.info("Receiving response from Spark UI: " + client_response)
         except requests.exceptions.RequestException:
             client_response = json.dumps({"error": "SPARK_NOT_RUNNING"})
@@ -47,3 +76,5 @@ def load_jupyter_server_extension(nb_server_app):
     host_pattern = ".*$"
     route_pattern = url_path_join(web_app.settings['base_url'], EXTENSION_URL) + ".*"
     web_app.add_handlers(host_pattern, [(route_pattern, SparkHandler)])
+
+    SparkHandler.web_app = url_path_join(web_app.settings['base_url'], EXTENSION_URL)

--- a/jupyter-spark/spark.py
+++ b/jupyter-spark/spark.py
@@ -70,7 +70,7 @@ class SparkHandler(IPythonHandler):
 def load_jupyter_server_extension(nb_server_app):
     # Extract our Spark server details from the config:
     cfg = nb_server_app.config["NotebookApp"]
-    SparkHandler.spark_host = cfg["spark_host"] or "http://localhost:4040"
+    SparkHandler.spark_host = cfg.get("spark_host", "http://localhost:4040")
 
     web_app = nb_server_app.web_app
     host_pattern = ".*$"

--- a/jupyter-spark/spark.py
+++ b/jupyter-spark/spark.py
@@ -35,7 +35,7 @@ class SparkHandler(IPythonHandler):
             self.set_header("Content-Type", content_type)
 
             if "text" in content_type:
-                # Replace all the relative links with our proxy crap
+                # Replace all the relative links with our proxy links
                 soup = BeautifulSoup(spark_response.text)
 
                 for has_href in ['a', 'link']:

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,11 @@ class InstallCommand(install):
 
 setup(
     name="jupyter-spark",
-    version="0.1.0",
+    version="0.1.1",
     description="Jupyter Notebook extension for Apache Spark integration",
     packages=["jupyter-spark"],
     package_data={'': ['extensions/spark.js']},
-    install_requires = ["ipython >= 4", "jupyter-pip", "jupyter", "requests"],
+    install_requires = ["ipython >= 4", "jupyter-pip", "jupyter", "requests", "beautifulsoup"],
     url="https://github.com/mreid-moz/jupyter-spark",
     cmdclass = {"install": InstallCommand}
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     description="Jupyter Notebook extension for Apache Spark integration",
     packages=["jupyter-spark"],
     package_data={'': ['extensions/spark.js']},
-    install_requires = ["ipython >= 4", "jupyter-pip", "jupyter", "requests", "beautifulsoup"],
+    install_requires = ["ipython >= 4", "jupyter-pip", "jupyter", "requests", "beautifulsoup4"],
     url="https://github.com/mreid-moz/jupyter-spark",
     cmdclass = {"install": InstallCommand}
 )


### PR DESCRIPTION
This un-breaks the links on the Spark UI proxy (visit localhost:8888/spark/) and makes images and css/js work as expected.

I didn't check how it impacts the api calls used by the "list running jobs" - we might need to add an exception for `/spark/api`.

I'm open to less hackish suggestions too :)
Before:
<img width="400" alt="unmodified content" src="https://cloud.githubusercontent.com/assets/969479/13812931/7c4db29e-eb5d-11e5-9cb7-d952d1d3bd91.png">

After (clicking on the "environment" link):
<img width="400" alt="hackishly modified content" src="https://cloud.githubusercontent.com/assets/969479/13812935/82b791fe-eb5d-11e5-9ba8-2d1685213cca.png">

@yeah568 and @musicaljelly please review.

