### PR TITLE
Pin tornado version at < 6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ recreate = true
 commands =
     py.test {posargs}
 deps:
-    tornado
+    tornado<6
     coverage>=4.0
     pytest-isort
     pytest-cache>=1.0


### PR DESCRIPTION
Resolves the error "AttributeError: module 'tornado.web' has no attribute 'asynchronous'", which is breaking the Travis build.